### PR TITLE
[Escalation] Updates `botocore` and related dependency requirements

### DIFF
--- a/amzn/requirements.txt
+++ b/amzn/requirements.txt
@@ -15,11 +15,11 @@ attrs==23.1.0
     #   referencing
 backoff==2.2.1
     # via -r ./extra-requirements.txt
-boto3<2.0
+boto3>=1.17.0,<2.0
     # via
     #   -r ./selling-partner-api-models/clients/sellingpartner-api-aa-python/requirements.txt
     #   python-amazon-sp-api
-botocore<2.0
+botocore>=1.20.0,<2.0
     # via
     #   -r ./selling-partner-api-models/clients/sellingpartner-api-aa-python/requirements.txt
     #   boto3
@@ -138,7 +138,7 @@ rpds-py==0.8.10
     #   -r ./selling-partner-api-models/clients/sellingpartner-api-aa-python/requirements.txt
     #   jsonschema
     #   referencing
-s3transfer<1.0
+s3transfer>=0.3.3,<1.0
     # via
     #   -r ./selling-partner-api-models/clients/sellingpartner-api-aa-python/requirements.txt
     #   boto3

--- a/amzn/requirements.txt
+++ b/amzn/requirements.txt
@@ -147,7 +147,7 @@ simplejson==3.17.2
     #   -r ./selling-partner-api-models/clients/sellingpartner-api-aa-python/requirements.txt
     #   bravado
     #   bravado-core
-six==1.14.0
+six>=1.16.0
     # via
     #   -r ./amzn/requirements.txt
     #   -r ./selling-partner-api-models/clients/sellingpartner-api-aa-python/requirements.txt

--- a/amzn/requirements.txt
+++ b/amzn/requirements.txt
@@ -15,11 +15,11 @@ attrs==23.1.0
     #   referencing
 backoff==2.2.1
     # via -r ./extra-requirements.txt
-boto3==1.16.39
+boto3<2.0
     # via
     #   -r ./selling-partner-api-models/clients/sellingpartner-api-aa-python/requirements.txt
     #   python-amazon-sp-api
-botocore==1.19.39
+botocore<2.0
     # via
     #   -r ./selling-partner-api-models/clients/sellingpartner-api-aa-python/requirements.txt
     #   boto3
@@ -138,7 +138,7 @@ rpds-py==0.8.10
     #   -r ./selling-partner-api-models/clients/sellingpartner-api-aa-python/requirements.txt
     #   jsonschema
     #   referencing
-s3transfer==0.3.3
+s3transfer<1.0
     # via
     #   -r ./selling-partner-api-models/clients/sellingpartner-api-aa-python/requirements.txt
     #   boto3


### PR DESCRIPTION
Blocked by #17 

**Summary:**
We need to update the main `shortstory` repo to Python 3.10.x, but to do so we need to relax the dependencies from this repo.

**Additional Context:**
When migration from python 3.9 to 3.10, any libraries using an old version (<1.15?) of `six` will break. `botocore` is one of those libraries, and we can't force the transitive dependency because the current version is using a _vendored_ version of `six`

To avoid potentially breaking changes, I've opted to only relax the dependencies on the libraries I know to be a problem:

- `botocore`: Currently using a vendored version of `six`
- `boto3`: Depends on `botocore`
- `s3transfer`: Depends on `botocore`
- `six`: ... force to use the relevant version